### PR TITLE
Added support for long tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 asn1js
 ======
 
-asn1js is a JavaScript generic ASN.1 parser/decoder that can decode any valid ASN.1 DER or BER structures.
+asn1js is a JavaScript generic ASN.1 parser/decoder that can decode any valid ASN.1 DER or BER structures. It supports all ASN.1 tag classes, tag numbers up to 28 bits and contents lengths up to 24 bits (extended tag support added by [Péter Budai](https://www.peterbudai.eu/)).
 
 An example page that can decode Base64-encoded (raw base64, PEM armoring and `begin-base64` are recognized) or Hex-encoded (or local files with some browsers) is included and can be used both [online on the official website](http://lapo.it/asn1js/) or [offline (ZIP file)](http://lapo.it/asn1js/asn1js.zip).
 
@@ -16,10 +16,10 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-links
+Links
 ------
 
-- [official website](http://lapo.it/asn1js/)
+- [Official website](http://lapo.it/asn1js/)
 - [InDefero tracker](http://idf.lapo.it/p/asn1js/)
-- [github mirror](https://github.com/lapo-luchini/asn1js)
+- [GitHub mirror](https://github.com/lapo-luchini/asn1js)
 - [Ohloh code stats](https://www.ohloh.net/p/asn1js)


### PR DESCRIPTION
The previous version of the library did not process tag numbers greater
than 30 correctly, which caused desynchronization of the input stream and
lead to other decoding errors on many real world ASN.1 structures.

This patch introduces a new function for decoding long tag values, and
contains refactorings to handle greater tag numbers correctly.
