### PR TITLE
Add missing '00 00' to the hex dump of the outro of indefinite length empty parts

### DIFF
--- a/dom.js
+++ b/dom.js
@@ -159,6 +159,8 @@ ASN1.prototype.toHexDOM = function (root) {
         for (var i = 0, max = this.sub.length; i < max; ++i)
             node.appendChild(this.sub[i].toHexDOM(root));
         this.toHexDOM_sub(node, "outro", this.stream, last.posEnd(), this.posEnd());
+    } else {
+        this.toHexDOM_sub(node, "outro", this.stream, this.posContent(), this.posEnd());
     }
     return node;
 };


### PR DESCRIPTION
If the decoded ASN1 was '30 80 00 00' then the hex dump showed only '30 80'
