### PR TITLE
Throw error on parsing multi-octet tag number smaller with tag number 31

### DIFF
--- a/asn1.js
+++ b/asn1.js
@@ -522,6 +522,9 @@ function ASN1Tag(stream) {
             n.mulAdd(128, buf & 0x7F);
         } while (buf & 0x80);
         this.tagNumber = n.simplify();
+        if (this.tagNumber < 0x1F) {
+            throw 'Tag number ' + this.tagNumber + ' is smaller than 31, so it shall not use multi octet tag format';
+        }
     }
 }
 ASN1Tag.prototype.isUniversal = function () {


### PR DESCRIPTION
ITU X.690-0270

8.1.2.2 For tags with a number ranging from zero to 30 (inclusive), the identifier octets shall comprise a single octet
encoded as follows:

8.1.2.4 For tags with a number greater than or equal to 31, the identifier shall comprise a leading octet followed by
one or more subsequent octets.