### PR TITLE
Option to 'un-trim' big hex chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ git-*.txt
 node_modules
 package-lock.json
 pnpm-lock.yaml
+
+# Artifacts from parseRFC.js
+# Maybe we should commit this to the repo?
+rfc*
+
+# From updateOID.sh
+dumpasn1.cfg

--- a/dom.js
+++ b/dom.js
@@ -159,7 +159,7 @@ class ASN1DOM extends ASN1 {
             stream.hexDump(start, end)));
         node.appendChild(sub);
     }
-    toHexDOM(root) {
+    toHexDOM(root, trim=true) {
         let node = DOM.tag('span', 'hex');
         if (root === undefined) root = node;
         this.head.hexNode = node;
@@ -174,7 +174,7 @@ class ASN1DOM extends ASN1 {
             }
             this.asn1.fakeHover(current);
         };
-        node.onmouseout  = function () {
+        node.onmouseout = function () {
             let current = (root.selected == this.asn1);
             this.asn1.fakeOut(current);
             if (current) {
@@ -200,7 +200,7 @@ class ASN1DOM extends ASN1 {
         if (this.sub === null) {
             let start = this.posContent();
             let end = this.posEnd();
-            if (end - start < 10 * 16)
+            if (!trim || end - start < 10 * 16)
                 node.appendChild(DOM.text(
                     this.stream.hexDump(start, end)));
             else {
@@ -219,7 +219,7 @@ class ASN1DOM extends ASN1 {
             let last = this.sub[this.sub.length - 1];
             this.toHexDOM_sub(node, 'intro', this.stream, this.posContent(), first.posStart());
             for (let i = 0, max = this.sub.length; i < max; ++i)
-                node.appendChild(this.sub[i].toHexDOM(root));
+                node.appendChild(this.sub[i].toHexDOM(root, trim));
             this.toHexDOM_sub(node, 'outro', this.stream, last.posEnd(), this.posEnd());
         } else
             this.toHexDOM_sub(node, 'outro', this.stream, this.posContent(), this.posEnd());

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
       <br>
       <br>
       <label title="can be slow with big files"><input type="checkbox" id="wantHex" checked="checked"> with hex dump</label>
+      <label title="can be slow with big files"><input type="checkbox" id="trimHex" checked="checked"> trim big chunks</label>
       <label title="can be slow with big files"><input type="checkbox" id="wantDef" checked="checked"> with definitions</label>
       <input id="butDecode" type="button" value="decode">
       <br><br>

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const
     tree = id('tree'),
     dump = id('dump'),
     wantHex = checkbox('wantHex'),
+    trimHex = checkbox('trimHex'),
     wantDef = checkbox('wantDef'),
     area = id('area'),
     file = id('file'),
@@ -46,7 +47,7 @@ function show(asn1) {
     tree.innerHTML = '';
     dump.innerHTML = '';
     tree.appendChild(asn1.toDOM());
-    if (wantHex.checked) dump.appendChild(asn1.toHexDOM());
+    if (wantHex.checked) dump.appendChild(asn1.toHexDOM(undefined, trimHex.checked));
 }
 function decode(der, offset) {
     offset = offset || 0;


### PR DESCRIPTION
Today it isn't possible to easily get the full hexdump of tags bigger than 160 bytes:

![truncated hex dump](https://user-images.githubusercontent.com/8722223/229311765-eb3029b3-00ba-4468-91c7-86d31a6fc313.png)

This PR adds a new checkbox that allows showing the full dump (feel free to suggest a better checkbox label)

![checkbox to show full dump](https://user-images.githubusercontent.com/8722223/229311812-940fa17c-5217-450e-bbd3-d6e00a361e33.png)

Which will render the full hexdump:

![full hexdump](https://user-images.githubusercontent.com/8722223/229311865-018e4cc2-e5ac-4526-8bcf-c2668c84356a.png)
