### PR TITLE
fallback to type ANY when content is TODO:unknown

### DIFF
--- a/defs.js
+++ b/defs.js
@@ -87,7 +87,11 @@ class Defs {
                     else {
                         let tn = subval.typeName(); //.replaceAll('_', ' ');
                         do {
-                            type = def.content[j++];
+                            if (def.content == "TODO:unknown") {
+                                type = {name: "ANY", type: "builtin"}
+                            } else {
+                                type = def.content[j++];
+                            }
                             // type = translate(type, tn);
                             if (type?.type?.type)
                                 type = type.type;


### PR DESCRIPTION
This fixes #65

When trying to parse data with unknown content (`"TODO:unknown"`) the parser fails on calling `in` on a String. This commit uses `type = {name: "ANY", type: "builtin"}` as a default value for this situation.