### PR TITLE
fix: don't throw exception on invalid BitString and Utf8String

### DIFF
--- a/asn1.js
+++ b/asn1.js
@@ -292,7 +292,7 @@ class Stream {
         let len = end - start,
             s;
         try {
-            s = this.parseStringUTF(start, end, maxLength);
+            s = this.parseUTF8inner(start, end, maxLength);
             checkPrintable(s.str);
             return { size: end - start, str: s.str };
         } catch (e) {

--- a/index.js
+++ b/index.js
@@ -49,6 +49,18 @@ function show(asn1) {
     tree.appendChild(asn1.toDOM());
     if (wantHex.checked) dump.appendChild(asn1.toHexDOM(undefined, trimHex.checked));
 }
+function skipPadding(der, offset) {
+    let skip = 0;
+    while ((offset+skip) < der.length) {
+        let pos = offset+skip;
+        let b = (typeof der == 'string') ? der.charCodeAt(pos) : der[pos];
+        if (b != 0x00 && b != 0xFF) {
+            break;
+        }
+        skip += 1;
+    }
+    return skip;
+}
 function decode(der, offset) {
     offset = offset || 0;
     try {
@@ -94,10 +106,12 @@ function decode(der, offset) {
         }
         let endOffset = asn1.posEnd();
         if (endOffset < der.length) {
+            let skip = skipPadding(der, endOffset);
+            endOffset += skip;
             let p = document.createElement('p');
             p.innerText = 'Input contains ' + (der.length - endOffset) + ' more bytes to decode.';
             let button = document.createElement('button');
-            button.innerText = 'try to decode';
+            button.innerText = 'try to decode' + (skip > 0 ? ' (skip '+skip+' zeros)':'');
             button.onclick = function () {
                 decode(der, endOffset);
             };

--- a/index.js
+++ b/index.js
@@ -105,9 +105,9 @@ function decode(der, offset) {
             window.location.hash = hash = '#';
         }
         let endOffset = asn1.posEnd();
+        let skip = skipPadding(der, endOffset);
+        endOffset += skip;
         if (endOffset < der.length) {
-            let skip = skipPadding(der, endOffset);
-            endOffset += skip;
             let p = document.createElement('p');
             p.innerText = 'Input contains ' + (der.length - endOffset) + ' more bytes to decode.';
             let button = document.createElement('button');


### PR DESCRIPTION
So there is an ISO/RFC example with 2 invalid ASN.1 values: BIT STRING and UTF8String
All the other tags are valid.

With `throw new Error(...)` the ASN.1 JS Decoder wouldn't show anything.
And yes, they really put an invalid example in kinda-new ISO/IEC from 2016.

Thanks for the awesome project.

Here's how it looks like parsed now:


![obraz](https://github.com/lapo-luchini/asn1js/assets/141624503/2f872a88-dca6-4040-8767-166f92dc5522)

