### PR TITLE
Use more contrast colors for recognized names of fields

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,6 +1,7 @@
 html {
     --main-bg-color: #C0C0C0;
     --main-text-color: #000000;
+    --id-text-color: #7d5900;
     --headline-text-color: #8be9fd;
     --button-border-color: #767676;
     --button-bg-color: #efefef;
@@ -35,6 +36,7 @@ html {
 html[data-theme="dark"] {
     --main-bg-color: #0d1116;
     --main-text-color: #f8f8f2;
+    --id-text-color: #9d7c2d;
     --headline-text-color: #8be9fd;
     --button-border-color: #505050;
     --button-bg-color: #303030;
@@ -186,7 +188,7 @@ header {
     color: var(--preview-border-color);
 }
 .name.id {
-    color: var(--main-text-color);
+    color: var(--id-text-color);
 }
 .value {
     display: none;


### PR DESCRIPTION
With old colors, it is difficult to distinguish a recognized field name from a type name, and as a result, it is difficult to understand where names were recognized and where they were not.

Examples:
Dark theme:

|Old|New|
|---|---|
|<img width="798" height="313" alt="old dark" src="https://github.com/user-attachments/assets/fa7c47dd-d56e-4bed-ac17-1743537014f6" />|<img width="798" height="313" alt="new dark" src="https://github.com/user-attachments/assets/42c6bf89-81a1-4f31-afc2-e37e206f2b06" />|

Light theme:
|Old|New|
|---|---|
|<img width="798" height="313" alt="old light" src="https://github.com/user-attachments/assets/bf87a6d9-e55f-4383-9a33-61543a8800d8" />|<img width="798" height="313" alt="new light" src="https://github.com/user-attachments/assets/88746d27-3fe9-4c9a-acf6-e4501933aa56" />|