### PR TITLE
Check for zero content length on universal tags where it is not allowed

### DIFF
--- a/asn1.js
+++ b/asn1.js
@@ -459,6 +459,14 @@ export class ASN1 {
             let d1 = this.stream.parseOctetString(content, content + len, maxLength);
             return '(' + d1.size + ' byte)\n' + d1.str;
         }
+        if (len === 0) {
+            switch (this.tag.tagNumber) {
+                case 1:
+                case 2:
+                case 6:
+	                return "invalid length 0";
+            }
+        }
         switch (this.tag.tagNumber) {
         case 0x01: // BOOLEAN
             return (this.stream.get(content) === 0) ? 'false' : 'true';

--- a/asn1.js
+++ b/asn1.js
@@ -461,9 +461,9 @@ export class ASN1 {
         }
         if (len === 0) {
             switch (this.tag.tagNumber) {
-                case 1:
-                case 2:
-                case 6:
+                case 0x01: // BOOLEAN
+                case 0x02: // INTEGER
+                case 0x06: // OBJECT_IDENTIFIER
 	                return "invalid length 0";
             }
         }


### PR DESCRIPTION
Zero content length is not allowed for BOOLEAN, INTEGER, and OBJECT IDENTIFIER universal tags. Then `invalid length 0` is displayed.

Enclosed screenshots of SPNEGO request and response demonstrating the feature. These packets are using "pseudo-ASN.1" as specified in [Section 4.1 of RFC 4212](https://datatracker.ietf.org/doc/html/rfc4121#se
<img width="1010" height="942" alt="initial-token" src="https://github.com/user-attachments/assets/b54fea1d-4b11-482d-b143-80251e25d387" />
<img width="924" height="471" alt="negotiation-token" src="https://github.com/user-attachments/assets/4b485ac3-f039-4490-a2ae-5ae2548c488e" />
ction-4.1)